### PR TITLE
Check for 53 as listening port

### DIFF
--- a/pyclient/zeroos/orchestrator/sal/gateway/dhcp.py
+++ b/pyclient/zeroos/orchestrator/sal/gateway/dhcp.py
@@ -42,5 +42,5 @@ class DHCP:
 
     def is_running(self):
         for port in self.container.client.info.port():
-            if port['network'] == 'udp' and port['port'] == 67:
+            if port['network'] == 'udp' and port['port'] == 53:
                 return True

--- a/templates/cloudinit/actions.py
+++ b/templates/cloudinit/actions.py
@@ -1,4 +1,4 @@
-def install(job):
+def start(job):
     gateway = job.service.parent.consumers['gateway'][0]
     gwdata = gateway.model.data.to_dict()
 

--- a/templates/dhcp/actions.py
+++ b/templates/dhcp/actions.py
@@ -1,4 +1,4 @@
-def install(job):
+def start(job):
     gateway = job.service.parent.consumers['gateway'][0]
     gwdata = gateway.model.data.to_dict()
     apply_config(job, gwdata)

--- a/templates/firewall/actions.py
+++ b/templates/firewall/actions.py
@@ -1,4 +1,4 @@
-def install(job):
+def start(job):
     gateway = job.service.parent.consumers['gateway'][0]
     gwdata = gateway.model.data.to_dict()
     apply_rules(job, gwdata)

--- a/templates/gateway/actions.py
+++ b/templates/gateway/actions.py
@@ -243,10 +243,10 @@ def start(job):
     firewall = container.consumers.get('firewall')[0]
 
     j.tools.async.wrappers.sync(container.executeAction('start', context=job.context))
-    j.tools.async.wrappers.sync(http.executeAction('install', context=job.context))
-    j.tools.async.wrappers.sync(dhcp.executeAction('install', context=job.context))
-    j.tools.async.wrappers.sync(firewall.executeAction('install', context=job.context))
-    j.tools.async.wrappers.sync(cloudinit.executeAction('install', context=job.context))
+    j.tools.async.wrappers.sync(http.executeAction('start', context=job.context))
+    j.tools.async.wrappers.sync(dhcp.executeAction('start', context=job.context))
+    j.tools.async.wrappers.sync(firewall.executeAction('start', context=job.context))
+    j.tools.async.wrappers.sync(cloudinit.executeAction('start', context=job.context))
     service.model.data.status = "running"
 
 

--- a/templates/http/actions.py
+++ b/templates/http/actions.py
@@ -1,4 +1,4 @@
-def install(job):
+def start(job):
     gateway = job.service.parent.consumers['gateway'][0]
     gwdata = gateway.model.data.to_dict()
     httpproxies = gwdata.get('httpproxies', [])


### PR DESCRIPTION
We want to check on 53 instead of 67 as dns will always be listening
DHCP port is only listening when hosts are passed

Change all gateway related services to have an actor called start
instead of install
This is to prevent raise conditions when someone supplies a blueprint
with an generic (not actor specified) install action

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>