### PR TITLE
Update caddy/nft templates + mtu

### DIFF
--- a/pyclient/zeroos/orchestrator/sal/templates/caddy.conf
+++ b/pyclient/zeroos/orchestrator/sal/templates/caddy.conf
@@ -1,6 +1,6 @@
 
 {% for httpproxy in httpproxies %}
-{% if 'http' in httpproxy.types and 'https' in httpproxies.types -%}
+{% if 'http' in httpproxy.types and 'https' in httpproxy.types -%}
 {{httpproxy.host}} {
 {% elif 'http' in httpproxy.types -%}
 http://{{httpproxy.host}} {

--- a/pyclient/zeroos/orchestrator/sal/templates/nftables.conf
+++ b/pyclient/zeroos/orchestrator/sal/templates/nftables.conf
@@ -45,6 +45,7 @@ table inet filter {
 		iif $allifs ether type arp accept
 		# allow IPv6 'L2' stuff
 		ip6 daddr & :: == :: icmpv6 type $icmpv6_ok accept
+		tcp dport { http, https } accept
 		# no connections from the CS to this VR without verification
 		iif $priv_iface jump private
 		# for good measure ;-)
@@ -79,8 +80,6 @@ table inet filter {
 		# do we want tcp dns ?
 		udp dport { domain, bootps } accept
 		tcp dport domain accept
-		# we want http for cloud-init
-		tcp dport { http, https } accept
 		counter drop
 	}
 }

--- a/templates/network.switchless/actions.py
+++ b/templates/network.switchless/actions.py
@@ -55,4 +55,5 @@ def configure(job):
     if 'vxbackend' not in nicmap:
         container_client.json('ovs.vlan-ensure', {'master': 'backplane', 'vlan': service.model.data.vlanTag, 'name': 'vxbackend'})
         node.client.system('ip address add {vxaddr} dev vxbackend'.format(**addresses)).get()
+        node.client.system('ip link set dev vxbackend mtu 2000').get()
         node.client.system('ip link set dev vxbackend up').get()

--- a/templates/network.zero-os/actions.py
+++ b/templates/network.zero-os/actions.py
@@ -50,4 +50,5 @@ def configure(job):
         container_client.json(
             'ovs.vlan-ensure', {'master': 'backplane', 'vlan': service.model.data.vlanTag, 'name': 'vxbackend'})
         node.client.system('ip address add {vxaddr} dev vxbackend'.format(**addresses)).get()
+        node.client.system('ip link set dev vxbackend mtu 2000').get()
         node.client.system('ip link set dev vxbackend up').get()


### PR DESCRIPTION
Set vxbackend to mtu of 2000
Update caddy template to properly support https
Open port 80 and 443 by default on gateway

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>