### PR TITLE
Remove hard-js9 dependency during basic sal import

### DIFF
--- a/pyclient/setup.py
+++ b/pyclient/setup.py
@@ -24,5 +24,5 @@ setup(
         'zeroos.orchestrator.sal.templates': ['*.conf', 'dhcp', 'dashboards/*']
     },
     namespace_packages=['zeroos'],
-    install_requires=['python-dateutil', 'Jinja2', 'aioredis', 'etcd3'],
+    install_requires=['python-dateutil', 'Jinja2', 'aioredis', 'etcd3', 'netaddr'],
 )

--- a/pyclient/zeroos/orchestrator/sal/abstracts.py
+++ b/pyclient/zeroos/orchestrator/sal/abstracts.py
@@ -1,6 +1,3 @@
-from js9 import j
-
-
 class Mountable:
     """
     Abstract implementation for devices that are mountable.
@@ -34,34 +31,3 @@ class Mountable:
                 source=self.mountpoint,
             )
         self.mountpoint = None
-
-
-class AYSable:
-    """
-    Abstract implementation for class that reflect an AYS service.
-    class should have a name and actor attributes
-
-    This provide common method to CRUD AYS service from the python classes
-    """
-    @property
-    def name(self):
-        return self._obj.name
-
-    @property
-    def role(self):
-        return self.actor.split('.')[0]
-
-    def create(self, aysrepo):
-        """
-        create the AYS Service
-        """
-        raise NotImplementedError()
-
-    def get(self, aysrepo):
-        """
-        get the AYS service
-        """
-        try:
-            return aysrepo.serviceGet(role=self.role, instance=self.name)
-        except j.exceptions.NotFound:
-            raise ValueError("Could not find {} with name {}".format(self.role, self.name))

--- a/pyclient/zeroos/orchestrator/sal/atyourservice/StoragePool.py
+++ b/pyclient/zeroos/orchestrator/sal/atyourservice/StoragePool.py
@@ -1,4 +1,4 @@
-from ..abstracts import AYSable
+from .abstracts import AYSable
 from js9 import j
 
 

--- a/pyclient/zeroos/orchestrator/sal/atyourservice/abstract.py
+++ b/pyclient/zeroos/orchestrator/sal/atyourservice/abstract.py
@@ -1,0 +1,31 @@
+from js9 import j
+
+class AYSable:
+    """
+    Abstract implementation for class that reflect an AYS service.
+    class should have a name and actor attributes
+
+    This provide common method to CRUD AYS service from the python classes
+    """
+    @property
+    def name(self):
+        return self._obj.name
+
+    @property
+    def role(self):
+        return self.actor.split('.')[0]
+
+    def create(self, aysrepo):
+        """
+        create the AYS Service
+        """
+        raise NotImplementedError()
+
+    def get(self, aysrepo):
+        """
+        get the AYS service
+        """
+        try:
+            return aysrepo.serviceGet(role=self.role, instance=self.name)
+        except j.exceptions.NotFound:
+            raise ValueError("Could not find {} with name {}".format(self.role, self.name))

--- a/pyclient/zeroos/orchestrator/sal/healthcheck.py
+++ b/pyclient/zeroos/orchestrator/sal/healthcheck.py
@@ -1,9 +1,8 @@
-from js9 import j
 import os
 from zeroos.core0.client.client import Timeout
 import json
 import hashlib
-
+import traceback
 
 class HealthCheckObject:
     def __init__(self, id, name, category, resource):
@@ -33,8 +32,8 @@ class HealthCheckRun(HealthCheckObject):
         try:
             self.run(*args, **kwargs)
         except Exception as e:
-            eco = j.errorhandler.parsePythonExceptionObject(e)
-            self.stacktrace = eco.traceback
+            self.stacktrace = traceback.format_exc()
+
         return self.to_dict()
 
 


### PR DESCRIPTION
This pull request try to reduce js9 dependency at least for basic runtime (not complains about import missing when just import Node from SAL for exemple).