### PR TITLE
cover disk usage healthcheck

### DIFF
--- a/tests/0_orchestrator/test_suite/framework/orchestrator_apis/health_apis.py
+++ b/tests/0_orchestrator/test_suite/framework/orchestrator_apis/health_apis.py
@@ -12,8 +12,8 @@ class HealthcheckAPI:
         return self.orchestrator_client.health.ListNodesHealth()
 
     @catch_exception_decoration
-    def get_node_health(self, node_id):
-        return self.orchestrator_client.health.ListNodeHealth(nodeid=node_id)
+    def get_node_health(self, nodeid):
+        return self.orchestrator_client.health.ListNodeHealth(nodeid=nodeid)
 
     @catch_exception_decoration
     def get_storageclusters_health(self):

--- a/tests/0_orchestrator/test_suite/framework/orchestrator_driver.py
+++ b/tests/0_orchestrator/test_suite/framework/orchestrator_driver.py
@@ -63,5 +63,6 @@ class OrchasteratorDriver:
                 continue
             nodes_info.append({"id": node['id'],
                                "ip": node['ipaddress'],
-                               "status": node['status']})
+                               "status": node['status'],
+                               "hostname":node['hostname']})
         return nodes_info

--- a/tests/0_orchestrator/test_suite/testcases/basic_tests/test13_health_apis.py
+++ b/tests/0_orchestrator/test_suite/testcases/basic_tests/test13_health_apis.py
@@ -1,44 +1,99 @@
-import random
-import time
-import unittest
+import random, time, unittest
+from parameterized import parameterized
 from testcases.testcases_base import TestcasesBase
 
-
-class TesthealthcheckAPI(TestcasesBase):
+class TestNodeHealthcheckAPI(TestcasesBase):
 
     def setUp(self):
+        super().setUp()
+        self.core0_client.client.timeout = 20
         self.lg.info(' [*] Get healthcheck of random node ')
-        self.random_node = self.get_random_node()
-        response = self.healthcheck_api.get_node_health(self.random_node)
+        response = self.healthcheck_api.get_node_health(nodeid=self.nodeid)
         self.assertEqual(response.status_code, 200)
-        self.healthchecks = response.json()["healthchecks"]
-
-    @unittest.skip('https://github.com/zero-os/0-orchestrator/issues/950')
-    def test001_list_healthcheck(self):
+    
+    @unittest.skip('https://github.com/zero-os/0-orchestrator/issues/1332')
+    def test01_get_nodes_healthcheck(self):
         """ GAT-168
 
         **Test Scenario:**
 
-        #. Get list of nodes .
-        #. Get list of a nodes healthcheck,should succeed.
+        #. List all nodes health, should succeed with 200.
         #. Check that all nodes have health check, should succeed.
         #. Check that all nodes have the same status result.
         """
 
-        self.lg.info("Get list of nodes . ")
-        response = self.nodes_api.get_nodes()
-        self.assertEqual(response.status_code, 200)
-        nodes_result = response.json()
-
-        self.lg.info("Get list of a nodes healthcheck,should succeed.")
+        self.lg.info("[*] List all nodes health, should succeed with 200")
         response = self.healthcheck_api.get_all_nodes_health()
         self.assertEqual(response.status_code, 200)
-        health_result = response.json()
 
-        self.lg.info(" Check that all nodes have health check, should succeed. ")
-        self.assertEqual(len(health_result), len(nodes_result))
+        nodes_healthcheck = response.json() 
+        nodes_info = [{'id':node['id'], 'status':node['status'], 'hostname':node['hostname']} for node in self.nodes_info]
+        self.assertEqual(nodes_healthcheck, nodes_info)
 
-        self.lg.info("Check that all nodes have the same status result")
-        for node in health_result:
-            status = [n['status']for n in nodes_result if n['id'] == node['id']]
-            self.assertEqual(node['status'], status[0])
+    @parameterized.expand([(89, 'OK'), (91, 'WARNING'), (94, 'WARNING'), (95, 'ERROR'), (99, 'ERROR')])
+    def test02_disk_usage_checks(self, percentage, status):
+        """ GAT-169
+
+        **Test Scenario:**
+
+        #. Get random node (N0).
+        #. Choose random free device (DE0) from node (N0) devices.
+        #. Create storagepool (SP0) and attach device (DE0) to it, should succeed.
+        #. Create filesystem (FS0), should succeed.
+        #. Get node (N0) healthchecks, device (DE0) usage status should be (OK).
+        #. Write file (F0) with size equal to (91 %) of device (DE0) space.
+        #. Get node (N0) healthchecks, device (DE0) usage status should be (WARNING).
+        #. Remove file (F0).
+        #. Write file (F1) with size equal to (95 %) of device (DE0) space.
+        #. Get node (N0) healthchecks, device (DE0) usage status should be (ERROR).
+        #. Delete storagepool (SP0), should succeed.
+        """
+        self.lg.info('Choose random free device (DE0) from node (N0) devices')
+        node_free_disks = self.core0_client.getFreeDisks() 
+        target_disk = random.choice(node_free_disks)
+
+        self.lg.info('Create storagepool (SP0) and attach device (DE0) to it, should succeed')
+        response, storagepool = self.storagepools_api.post_storagepools(self.nodeid, free_devices=[target_disk['name']])
+        self.assertEqual(response.status_code, 201)
+
+        self.lg.info('Create filesystem (FS0), should succeed')
+        response, filesystem = self.storagepools_api.post_storagepools_storagepoolname_filesystems(
+            self.nodeid, storagepool['name'], quota=0, readOnly=False
+        )
+        self.assertEqual(response.status_code, 201)
+
+        path = '/mnt/storagepools/{}/filesystems/{}'.format(storagepool['name'], filesystem['name'])
+
+        self.lg.info('Write file (F0) with size equal to ({} %) of device (DE0) space'.format(percentage))
+        filename = self.random_string()
+        filesize = int((percentage/100) * target_disk['size'])
+        
+        cmd = 'cd {path}; fallocate -l {filesize}G {filename}'.format(
+            path=path,
+            filename=filename,
+            filesize=filesize
+        )
+        response = self.core0_client.bash(cmd)
+        self.assertEqual(response.state, 'SUCCESS')
+
+        time.sleep(35)
+
+        self.lg.info('Get node (N0) healthchecks, device (DE0) usage status should be ({})'.format(status))
+
+        if target_disk['type'] == 'nvme':
+            targe_disk_name = '{}p1_usage'.format(target_disk['name'])
+        else:
+            targe_disk_name = '{}1_usage'.format(target_disk['name'])
+
+        response = self.healthcheck_api.get_node_health(nodeid=self.nodeid)
+        self.assertEqual(response.status_code, 200)
+
+        disks_usage = [x for x in  response.json()['healthchecks'] if x['id'] == 'disk-usage'][0]
+        target_disk_usage = [x for x in disks_usage['messages'] if x['id'] == targe_disk_name]
+        self.assertNotEqual(target_disk_usage, [])
+
+        self.assertEqual(target_disk_usage[0]['status'], status)
+      
+        self.lg.info('Delete storagepool (SP0), should succeed')
+        response = self.storagepools_api.delete_storagepools_storagepoolname(self.nodeid, storagepool['name'])
+        self.assertEqual(response.status_code, 204)

--- a/tests/0_orchestrator/test_suite/testcases/core0_client.py
+++ b/tests/0_orchestrator/test_suite/testcases/core0_client.py
@@ -10,6 +10,10 @@ class Client(TestCase):
     def stdout(self, resource):
         return resource.get().stdout.replace('\n', '').lower()
 
+    def bash(self, cmd):
+        response = self.client.bash(cmd).get()
+        return response
+
     def get_nodes_cpus(self):
         info = self.client.info.cpu()
         cpuInfo = []
@@ -157,7 +161,7 @@ class Client(TestCase):
                     else:
                         disktype = 'ssd'
 
-                current_disk = {'type':disktype, 'name':'/dev/{}'.format(disk['kname'])}
+                current_disk = {'type':disktype, 'name':'/dev/{}'.format(disk['kname']), 'size':int(diskSize)}
                 freeDisks.append(current_disk)
             
         return freeDisks


### PR DESCRIPTION
```
% nosetests -s -v testcases/basic_tests/test13_health_apis.py:TestNodeHealthcheckAPI --tc-file config.ini
GAT-168 ... SKIP: https://github.com/zero-os/0-orchestrator/issues/1332
GAT-169 [with percentage=89, status='OK'] ... ok
GAT-169 [with percentage=91, status='WARNING'] ... ok
GAT-169 [with percentage=94, status='WARNING'] ... ok
GAT-169 [with percentage=95, status='ERROR'] ... ok
GAT-169 [with percentage=99, status='ERROR'] ... ok

----------------------------------------------------------------------
Ran 6 tests in 386.918s

OK (SKIP=1)
```